### PR TITLE
ease negative letter spacing in header section for firefox

### DIFF
--- a/stylesheets/master.css
+++ b/stylesheets/master.css
@@ -40,7 +40,7 @@ header section
   { color: #252525;
     font-size: 110%;
     line-height: 150%;
-    letter-spacing: -0.1em; }
+    letter-spacing: -0.05em; }
 header section a
   { color: #252525; }
 


### PR DESCRIPTION
I know that in safari original letter spacing looks good but in firefox it is quite ugly ;)
